### PR TITLE
Update UIColor+Temperature.swift

### DIFF
--- a/Sample Project/UIColor+Temperature.swift
+++ b/Sample Project/UIColor+Temperature.swift
@@ -21,7 +21,7 @@ extension UIColor
         let red, green, blue: CGFloat
 
         red =   Self.clamp(percentKelvin <= 66 ? 255 : (329.698727446 * pow(percentKelvin - 60, -0.1332047592)));
-        green = Self.clamp(percentKelvin <= 66 ? (99.4708025861 * log(percentKelvin) - 161.1195681661) : 288.1221695283 * pow(percentKelvin, -0.0755148492));
+        green = Self.clamp(percentKelvin <= 66 ? (99.4708025861 * log(percentKelvin) - 161.1195681661) : 288.1221695283 * pow(percentKelvin - 60, -0.0755148492));
         blue =  Self.clamp(percentKelvin >= 66 ? 255 : (percentKelvin <= 19 ? 0 : 138.5177312231 * log(percentKelvin - 10) - 305.0447927307));
 
         self.init(red: red / 255, green: green / 255, blue: blue / 255, alpha: 1)


### PR DESCRIPTION
The green calculation was missing the "- 60" from the original algorithm:  
      tmpCalc = tmpKelvin - 60
        tmpCalc = 288.1221695283 * (tmpCalc ^ -0.0755148492)